### PR TITLE
disable flash of missing styles

### DIFF
--- a/assets/startup.js
+++ b/assets/startup.js
@@ -1,5 +1,8 @@
-$(function () {
-    for (let i in window.STUDIP.MyCSS.stylesheets) {
-        $('html').addClass(window.STUDIP.MyCSS.stylesheets[i]);
-    }
-});
+(function (STUDIP) {
+    'use strict';
+
+    const html = document.querySelector('html');
+    STUDIP.MyCSS.stylesheets.forEach(styleClass => {
+        html.classList.add(styleClass);
+    });
+}(STUDIP));


### PR DESCRIPTION
By invoking the setting of classes on `html` tag earlier, the initial flash of missing custom styles is prevented.

I also got rid of the neccessity of jQuery - in case this should/could be loaded even earlier.